### PR TITLE
#160814328 Enable Pagination support for articles

### DIFF
--- a/src/actions/__tests__/articles.test.js
+++ b/src/actions/__tests__/articles.test.js
@@ -1,168 +1,231 @@
 import React from "react";
 import Enzyme from "enzyme";
-import {deleteArticle, getArticle, getArticles, publishArticle, updateArticle} from "../articles";
+import {
+  deleteArticle,
+  getArticle,
+  getArticles,
+  publishArticle,
+  updateArticle
+} from "../articles";
 import Adapter from "enzyme-adapter-react-16";
 import configureMockStore from "redux-mock-store";
 import MockAdapter from "axios-mock-adapter";
-import {axiosInstance} from "../../globals";
+import { axiosInstance } from "../../globals";
 import {
-    ARTICLE_FAILURE,
-    ARTICLE_SUCCESS,
-    DELETE_ARTICLE, EDIT_ARTICLE,
-    FETCHING,
-    PREVIEW_ARTICLE, UPDATE_SLUG, UPDATE_STORE_ARTICLE, VIEW_ARTICLE,
-    VIEW_ARTICLES
+  ARTICLE_FAILURE,
+  ARTICLE_SUCCESS,
+  DELETE_ARTICLE,
+  EDIT_ARTICLE,
+  FETCHING,
+  PAGINATION_DATA,
+  PREVIEW_ARTICLE,
+  UPDATE_SLUG,
+  UPDATE_STORE_ARTICLE,
+  VIEW_ARTICLE,
+  VIEW_ARTICLES
 } from "../types";
-import {EditorState, convertFromRaw} from "draft-js";
+import { EditorState, convertFromRaw } from "draft-js";
 
 Enzyme.configure({ adapter: new Adapter() });
 
+export const testPaginationData = {
+  currentPage: 1,
+  hasNextPage: true,
+  hasPreviousPage: false,
+  nextPage: 2,
+  previousPage: 0,
+  range: [1, 2, 3, 4, 5],
+  totalPages: 5
+};
+
 describe("test articles", () => {
-  let store,get_response,get_article, update_response, response_data, httpMock, post_article, list_response;
+  let store,
+    get_response,
+    get_article,
+    update_response,
+    response_data,
+    httpMock,
+    post_article,
+    list_response;
   const flushAllPromises = () => new Promise(resolve => setImmediate(resolve));
 
   beforeEach(() => {
     const mockStore = configureMockStore();
     store = mockStore({ article: jest.fn() });
-    const editorBody = '{"blocks":[{"key":"1ulv2","text":"Where ","type":"header-five","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}],"entityMap":{}}'
+    const editorBody =
+      '{"blocks":[{"key":"1ulv2","text":"Where ","type":"header-five","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}],"entityMap":{}}';
     const contentState = convertFromRaw(JSON.parse(editorBody));
-    const body= EditorState.createWithContent(contentState);
+    const body = EditorState.createWithContent(contentState);
     post_article = {
-    title: "title",
-    body: body,
-    slug:"fake_slug",
-    description: "description"
+      title: "title",
+      body: body,
+      slug: "fake_slug",
+      description: "description"
     };
-     response_data = { title: "title", body:editorBody, slug: "fake_slug", error:{response:{data:{errors:""}}}};
+    response_data = {
+      title: "title",
+      body: editorBody,
+      slug: "fake_slug",
+      error: { response: { data: { errors: "" } } }
+    };
 
-     update_response = { title: "title", body:editorBody, slug: "fake_slug", description: "description"};
+    update_response = {
+      title: "title",
+      body: editorBody,
+      slug: "fake_slug",
+      description: "description"
+    };
 
-     get_article = { title: "title", body:body, slug: "fake_slug", description: "description", author:{username:"mike"}};
-     get_response = { title: "title", body:editorBody, slug: "fake_slug", description: "description", author:{username:"mike"}};
+    get_article = {
+      title: "title",
+      body: body,
+      slug: "fake_slug",
+      description: "description",
+      author: { username: "mike" }
+    };
+    get_response = {
+      title: "title",
+      body: editorBody,
+      slug: "fake_slug",
+      description: "description",
+      author: { username: "mike" }
+    };
 
-     list_response = { articles:[], error:{response:{data:{errors:""}}}};
-     httpMock = new MockAdapter(axiosInstance);
+    httpMock = new MockAdapter(axiosInstance);
+
+    list_response = {
+      articles: [],
+      number_of_pages: 5,
+      error: { response: { data: { errors: "" } } }
+    };
   });
 
-    it("should create article", async () => {
-    httpMock.onPost('/article/create').reply(201,response_data);
-        publishArticle(post_article)(store.dispatch);
-        await flushAllPromises();
-        expect(store.getActions()).toEqual([
-            {payload: true,type:FETCHING},
-            {payload: response_data.slug,type:UPDATE_SLUG},
-            {type:ARTICLE_SUCCESS,payload:"Article published successfully"},
-            {type:FETCHING,payload:false},
-            ])
+  it("should create article", async () => {
+    httpMock.onPost("/article/create").reply(201, response_data);
+    publishArticle(post_article)(store.dispatch);
+    await flushAllPromises();
+    expect(store.getActions()).toEqual([
+      { payload: true, type: FETCHING },
+      { payload: response_data.slug, type: UPDATE_SLUG },
+      { type: ARTICLE_SUCCESS, payload: "Article published successfully" },
+      { type: FETCHING, payload: false }
+    ]);
   });
 
-    it("test create article with error", async () => {
-        httpMock.onPost('/article/create').reply(400,response_data);
-        publishArticle(post_article)(store.dispatch);
-        await flushAllPromises();
-        expect(store.getActions()).toEqual([
-            {payload: true,type:FETCHING},
-            {type:ARTICLE_FAILURE,payload:"Failed to publish Article"},
-            {type:FETCHING,payload:false},
-        ])
+  it("test create article with error", async () => {
+    httpMock.onPost("/article/create").reply(400, response_data);
+    publishArticle(post_article)(store.dispatch);
+    await flushAllPromises();
+    expect(store.getActions()).toEqual([
+      { payload: true, type: FETCHING },
+      { type: ARTICLE_FAILURE, payload: "Failed to publish Article" },
+      { type: FETCHING, payload: false }
+    ]);
+  });
 
-    });
+  it("should update article", async () => {
+    httpMock
+      .onPut("/article/edit/" + post_article.slug)
+      .reply(200, update_response);
+    updateArticle(post_article)(store.dispatch);
+    await flushAllPromises();
+    expect(store.getActions()).toEqual([
+      { payload: true, type: FETCHING },
+      { type: UPDATE_STORE_ARTICLE, payload: post_article },
+      { type: ARTICLE_SUCCESS, payload: "Article updated successfully" },
+      { type: EDIT_ARTICLE, payload: false },
+      { type: FETCHING, payload: false }
+    ]);
+  });
 
-    it("should update article", async () => {
-        httpMock.onPut('/article/edit/'+post_article.slug).reply(200,update_response);
-        updateArticle(post_article)(store.dispatch);
-        await flushAllPromises();
-        expect(store.getActions()).toEqual([
-            {payload: true,type:FETCHING},
-            {type:UPDATE_STORE_ARTICLE,payload:post_article},
-            {type:ARTICLE_SUCCESS,payload:"Article updated successfully"},
-            {type:EDIT_ARTICLE,payload:false},
-            {type:FETCHING,payload:false}
-        ])
-    });
+  it("update article should fail", async () => {
+    httpMock
+      .onPut("/article/edit/" + post_article.slug)
+      .reply(400, response_data);
+    updateArticle(post_article)(store.dispatch);
+    await flushAllPromises();
+    expect(store.getActions()).toEqual([
+      { payload: true, type: FETCHING },
+      { type: ARTICLE_FAILURE, payload: "Failed to update Article" },
+      { type: FETCHING, payload: false }
+    ]);
+  });
 
-    it("update article should fail", async () => {
-        httpMock.onPut('/article/edit/'+post_article.slug).reply(400,response_data);
-        updateArticle(post_article)(store.dispatch);
-        await flushAllPromises();
-        expect(store.getActions()).toEqual([
-            {payload: true,type:FETCHING},
-            {type:ARTICLE_FAILURE,payload:"Failed to update Article"},
-            {type:FETCHING,payload:false},
-        ])
-    });
+  it("should get articles list", async () => {
+    httpMock.onGet("/articles?page=1").reply(200, list_response);
+    getArticles(1)(store.dispatch);
+    await flushAllPromises();
+    expect(store.getActions()).toEqual([
+      { type: FETCHING, payload: true },
+      { type: PREVIEW_ARTICLE, payload: false },
+      { type: VIEW_ARTICLES, payload: list_response.articles },
+      { type: PAGINATION_DATA, payload: testPaginationData },
+      { type: FETCHING, payload: false }
+    ]);
+  });
 
-    it("should get articles list", async () => {
-        httpMock.onGet('/articles?page=9000').reply(200,list_response);
-        getArticles(true)(store.dispatch);
-        await flushAllPromises();
-        expect(store.getActions()).toEqual([
-            {type: FETCHING, payload: true },
-            {type: PREVIEW_ARTICLE, payload: false },
-            {type: VIEW_ARTICLES,payload: list_response.articles},
-            {type: FETCHING, payload: false }
+  it("test fail to get articles list", async () => {
+    httpMock.onGet("/articles").reply(400, list_response);
+    getArticles(true)(store.dispatch);
+    await flushAllPromises();
+    expect(store.getActions()).toEqual([
+      { type: FETCHING, payload: true },
+      { type: ARTICLE_FAILURE, payload: "Failed to get Articles" },
+      { type: FETCHING, payload: false }
+    ]);
+  });
 
-        ])
-    });
+  it("should update article", async () => {
+    httpMock
+      .onPut("/article/edit/" + post_article.slug)
+      .reply(200, update_response);
+    updateArticle(post_article)(store.dispatch);
+    await flushAllPromises();
+    expect(store.getActions()).toEqual([
+      { payload: true, type: FETCHING },
+      { type: UPDATE_STORE_ARTICLE, payload: post_article },
+      { type: ARTICLE_SUCCESS, payload: "Article updated successfully" },
+      { type: EDIT_ARTICLE, payload: false },
+      { payload: false, type: FETCHING }
+    ]);
+  });
 
-    it("test fail to get articles list", async () => {
-        httpMock.onGet('/articles?page=9000').reply(400,list_response);
-        getArticles(true)(store.dispatch);
-        await flushAllPromises();
-        expect(store.getActions()).toEqual([
-            {type: FETCHING,payload: true},
-            {type: ARTICLE_FAILURE,payload: "Failed to get Articles"},
-            {type: FETCHING,payload: false} ]
-        )
-    });
+  it("should get an article", async () => {
+    httpMock
+      .onGet(`/article/get/${post_article.slug}`)
+      .reply(200, get_response);
+    getArticle(post_article.slug)(store.dispatch);
+    await flushAllPromises();
+    expect(store.getActions()).toEqual([
+      { payload: true, type: FETCHING },
+      { type: UPDATE_STORE_ARTICLE, payload: get_article },
+      { payload: true, type: VIEW_ARTICLE },
+      { type: FETCHING, payload: false }
+    ]);
+  });
 
-    it("should update article", async () => {
-        httpMock.onPut('/article/edit/'+post_article.slug).reply(200,update_response);
-        updateArticle(post_article)(store.dispatch);
-        await flushAllPromises();
-        expect(store.getActions()).toEqual([
-            {payload: true,type:FETCHING},
-            {type:UPDATE_STORE_ARTICLE,payload:post_article},
-            {type:ARTICLE_SUCCESS,payload:"Article updated successfully"},
-            {type:EDIT_ARTICLE,payload:false},
-            {payload: false,type:FETCHING}
-        ])
-    });
+  it("should fail to get an article", async () => {
+    httpMock
+      .onGet(`/article/get/${post_article.slug}`)
+      .reply(400, list_response);
+    getArticle()(store.dispatch);
+    await flushAllPromises();
+    expect(store.getActions()).toEqual([
+      { payload: true, type: FETCHING },
+      { type: ARTICLE_FAILURE, payload: "Failed to get Article" },
+      { type: FETCHING, payload: false }
+    ]);
+  });
 
-    it("should get an article", async () => {
-        httpMock.onGet(`/article/get/${post_article.slug}`).reply(200,get_response);
-        getArticle(post_article.slug)(store.dispatch);
-        await flushAllPromises();
-        expect(store.getActions()).toEqual([
-                {payload: true,type:FETCHING},
-                {type:UPDATE_STORE_ARTICLE,payload:get_article},
-                {payload: true, type: VIEW_ARTICLE},
-                {type:FETCHING,payload:false},
-            ]
-        )
-    });
-
-    it("should fail to get an article", async () => {
-        httpMock.onGet(`/article/get/${post_article.slug}`).reply(400,list_response);
-        getArticle()(store.dispatch);
-        await flushAllPromises();
-        expect(store.getActions()).toEqual([
-            {payload: true,type:FETCHING},
-            {type:ARTICLE_FAILURE,payload:"Failed to get Article"},
-            {type:FETCHING,payload:false},
-            ]
-        )
-    });
-
-    it("should fail delete an article", async () => {
-        httpMock.onGet(`/article/delete/${post_article.slug}`).reply(400,list_response);
-        deleteArticle(post_article.slug)(store.dispatch);
-        await flushAllPromises();
-        expect(store.getActions()).toEqual([
-                {payload: true,type:DELETE_ARTICLE},
-                {type:ARTICLE_FAILURE,payload:"Failed to delete Article"},
-            ]
-        )
-    });
-
+  it("should fail delete an article", async () => {
+    httpMock
+      .onGet(`/article/delete/${post_article.slug}`)
+      .reply(400, list_response);
+    deleteArticle(post_article.slug)(store.dispatch);
+    await flushAllPromises();
+    expect(store.getActions()).toEqual([
+      { payload: true, type: DELETE_ARTICLE },
+      { type: ARTICLE_FAILURE, payload: "Failed to delete Article" }
+    ]);
+  });
 });

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -24,6 +24,7 @@ export const UPDATE_STORE_ARTICLE = 'UPDATE_STORE_ARTICLE';
 export const UPDATE_AUTHOR = 'UPDATE_AUTHOR';
 export const UPDATE_SLUG = 'UPDATE_SLUG';
 export const CLEAR_MESSAGE = 'CLEAR_MESSAGE';
+export const PAGINATION_DATA = 'PAGINATION_DATA';
 
 // Profile action types
 export const FETCHING_PROFILE = 'FETCHING_PROFILE';

--- a/src/components/articles/ArticlesView.js
+++ b/src/components/articles/ArticlesView.js
@@ -2,11 +2,13 @@ import React from "react";
 import { connect } from "react-redux";
 import {getArticle, getArticles, viewArticle} from "../../actions";
 import PropTypes from "prop-types";
+import Paginate from "./Paginate";
 
 class ArticlesView extends React.Component {
 
     async componentWillMount() {
-        await this.props.getArticles(true);
+        await this.props.getArticles(1);
+
     }
 
    viewArticle = slugToView => {
@@ -16,15 +18,13 @@ class ArticlesView extends React.Component {
 
     render() {
         return (
-            <div className={"container article-view"}>
+            <div>{ this.props.paginationData.totalPages > 0 ? (<div className={"container article-view"}>
                 {
                 this.props.articles.map((article, index) => {
                     return (
                 <div className="row"  key={index}>
                 <div className="col s12 m12">
-                    <div role={'button'} className="card" onClick={()=>{this.viewArticle(article.slug)}}>
-                        <div>
-                </div>
+                    <div role={'button'} id={`article${index}`} className="card" onClick={()=>{this.viewArticle(article.slug)}}>
                         <div className="card-content">
                             <span className="card-title"><h5>{article.title}</h5></span>
                             <p>{article.description}</p>
@@ -36,6 +36,11 @@ class ArticlesView extends React.Component {
                 </div>
             </div>);
                 })}
+
+                <div className={"pagination center"}>
+                    <Paginate paginationData={this.props.paginationData} getArticles={this.props.getArticles}/>
+                </div>
+            </div>) :<p> </p> }
             </div>
         );
     }
@@ -53,6 +58,7 @@ ArticlesView.propTypes = {
 const mapStateToProps = state => {
     return {
         article: state.article,
+        paginationData: state.article.paginationData,
         articles: state.article.articlesList,
         message: state.article.message,
     };

--- a/src/components/articles/Paginate.js
+++ b/src/components/articles/Paginate.js
@@ -1,0 +1,93 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+class Paginate extends React.Component {
+  onClick = async pageNumber => {
+    await this.props.getArticles(pageNumber);
+  };
+
+  render() {
+    return (
+      <ul className="pagination center">
+        <FirstLastButton
+          currentPage={this.props.paginationData.currentPage}
+          page={1} onClick={this.onClick}
+          name={"first"}/>
+
+        {this.props.paginationData.hasPreviousPage && (
+          <li id={'chevron_left'} className={ 'waves-effect waves-light' }
+            onClick={ () => {
+              this.onClick(this.props.paginationData.currentPage - 1);} } >
+              <i className={"material-icons "}>chevron_left</i> </li> ) }
+
+        <PaginationList {...this.props} onClick={this.onClick}/>
+
+        { this.props.paginationData.hasNextPage &&
+          <li id={ 'chevron_right' } className={ 'waves-effect waves-light' }
+            onClick={() => {
+              this.onClick(this.props.paginationData.currentPage + 1); } } >
+            <i className="material-icons">chevron_right</i> </li> }
+
+        <FirstLastButton
+          currentPage={this.props.paginationData.currentPage}
+          page={this.props.paginationData.totalPages}
+          onClick={this.onClick}
+          name={"last"}
+        />
+      </ul>
+    );
+  }
+}
+
+const FirstLastButton = props => {
+  return (
+    props.currentPage !== props.page && (
+      <li className={ 'waves-effect waves-light' }>
+        <a
+          onClick={() => {
+            props.onClick(props.page);
+          }}
+          style={ { backgroundColor: "#e2ebfb" } }
+        >
+          {props.name}
+        </a>
+      </li>
+    )
+  );
+};
+
+const PaginationList = props => {
+  return (
+      props.paginationData.range.map((page, index) => {
+          return (
+            <li
+              id={`page${index}`}
+              className={ 'waves-effect waves-light' }
+              key={index}
+              onClick={() => {
+                props.onClick(page);
+              }}>
+              <a
+                style={
+                  props.paginationData.currentPage === page
+                    ? PaginationStyle : null
+                }>
+                {page}
+              </a>
+            </li>
+          );
+        })
+  );
+};
+
+
+Paginate.propTypes = {
+  paginationData: PropTypes.object.isRequired,
+  getArticles: PropTypes.func.isRequired
+};
+
+const PaginationStyle = {
+  backgroundColor: "#039be5",
+  color: "#FFFFFF"
+};
+export default Paginate;

--- a/src/components/articles/__tests__/Article.test.js
+++ b/src/components/articles/__tests__/Article.test.js
@@ -6,12 +6,16 @@ import ArticlePreview from "../ArticlePreview";
 import store from "../../../store";
 import ArticlesView from "../ArticlesView";
 import ArticleView from "../ArticleView";
+import Paginate from "../Paginate";
+import {testPaginationData} from "../../../actions/__tests__/articles.test";
 
 Enzyme.configure({adapter: new Adapter() });
 
 describe('Article Tests', () => {
 
     let articlesComponent;
+    const getArticles = jest.fn();
+    const viewArticle = jest.fn();
 
     beforeEach(() => {
         articlesComponent=mount(<ArticlesView store={store}  />);
@@ -25,12 +29,23 @@ describe('Article Tests', () => {
         shallow(<ArticlePreview article={{title: "title",slug:"sample_slug",body:"body"}}/>);
     });
 
-    it('should render articleviews without crashing', function () {
+    it('should render articlesview without crashing', function () {
         mount(<ArticlesView store={store} articles={{title:"title",body:"body",slug:"sample_slug"}} />);
-    })
+    });
 
     it('should render articleview without crashing', function () {
         shallow(<ArticleView store={store} articles={{title:"title",body:"body",slug:"sample_slug"}} />);
+    });
+    it('should render pagination without crashing', function () {
+        shallow(<Paginate  paginationData={testPaginationData} getArticles={jest.fn()}/>);
+    });
+
+    it('should go to page onclick ', function () {
+        const wrapper = mount(<Paginate  paginationData={testPaginationData} getArticles={getArticles}/>);
+        wrapper.find('#chevron_right').simulate('click');
+        wrapper.find('#page1').simulate('click');
+        expect(getArticles).toBeCalledTimes(2);
     })
+
 
 });

--- a/src/reducers/__tests__/articles.js
+++ b/src/reducers/__tests__/articles.js
@@ -1,11 +1,11 @@
 import {articleReducer,articleState} from "../articles";
 import {
     ARTICLE_FAILURE,
-    ARTICLE_SUCCESS,
+    ARTICLE_SUCCESS, CLEAR_MESSAGE,
     CREATE_ARTICLE,
     DELETE_ARTICLE,
     EDIT_ARTICLE, FETCHING,
-    PREVIEW_ARTICLE, UPDATE_AUTHOR, UPDATE_STORE_ARTICLE,
+    PREVIEW_ARTICLE, UPDATE_AUTHOR, UPDATE_SLUG, UPDATE_STORE_ARTICLE,
     VIEW_ARTICLE, VIEW_ARTICLES
 } from "../../actions/types";
 import {EditorState} from "draft-js";
@@ -99,6 +99,21 @@ describe('test articles reducer', () => {
         const action = {type: FETCHING, payload: true};
         const afterState = articleReducer(beforeState, action);
         beforeState.fetchStatus=true;
+        expect(afterState).toEqual(beforeState);
+    });
+
+    it('test update slug', () => {
+        const action = {type: UPDATE_SLUG, payload: ""};
+        const afterState = articleReducer(beforeState, action);
+        beforeState.fetchStatus=true;
+        expect(afterState).toEqual(beforeState);
+    });
+
+     it('test clear message', () => {
+        const action = {type: CLEAR_MESSAGE};
+        const afterState = articleReducer(beforeState, action);
+        beforeState.fetchStatus=true;
+        beforeState.message="";
         expect(afterState).toEqual(beforeState);
     });
 

--- a/src/reducers/articles.js
+++ b/src/reducers/articles.js
@@ -12,7 +12,7 @@ import {
     FETCHING,
     UPDATE_AUTHOR,
     UPDATE_SLUG,
-    CLEAR_MESSAGE
+    CLEAR_MESSAGE, PAGINATION_DATA
 } from "../actions/types";
 
 export const articleState = {
@@ -30,6 +30,9 @@ export const articleState = {
     isOwner:false,
   message: "",
   articlesList: [],
+    paginationData:{
+        totalPages:0
+    }
 };
 
 export const articleReducer = (state = articleState, action) => {
@@ -46,7 +49,7 @@ export const articleReducer = (state = articleState, action) => {
     case DELETE_ARTICLE:
       return { ...state, onDelete: action.payload };
     case VIEW_ARTICLES:
-      return { ...state, articlesList: action.payload , showList: true};
+      return { ...state, articlesList: action.payload , showList: true };
     case ARTICLE_SUCCESS:
       return {...state, message: action.payload};
     case UPDATE_STORE_ARTICLE:
@@ -61,7 +64,8 @@ export const articleReducer = (state = articleState, action) => {
       return {...state, slug: action.payload};
     case CLEAR_MESSAGE:
       return {...state, message: ""};
-
+    case PAGINATION_DATA:
+      return {...state, paginationData: action.payload};
     default:
       return { ...state };
   }


### PR DESCRIPTION
#### What does this PR do?
enables users traverse through articles 

#### Description of Task to be completed?
- add pagination component
- write tests
#### How should this be manually tested?
- run the project with `npm start`
- navigate to Articles on the menu and paginate at the bottom of the window.
#### What are the relevant pivotal tracker stories?
[#160814328](https://www.pivotaltracker.com/story/show/160814328)
#### Screenshots
<img width="1035" alt="screen shot 2018-10-23 at 15 17 35" src="https://user-images.githubusercontent.com/20810749/47360042-ffef0500-d6d6-11e8-86be-1b38777e3015.png">
<img width="1024" alt="screen shot 2018-10-23 at 15 18 12" src="https://user-images.githubusercontent.com/20810749/47360043-ffef0500-d6d6-11e8-8d2f-dee935e3608c.png">
<img width="1079" alt="screen shot 2018-10-23 at 15 18 25" src="https://user-images.githubusercontent.com/20810749/47360044-ffef0500-d6d6-11e8-829a-e914eb767deb.png">
